### PR TITLE
Update EpiRoute.php

### DIFF
--- a/src/libraries/external/epi/EpiRoute.php
+++ b/src/libraries/external/epi/EpiRoute.php
@@ -87,7 +87,6 @@ class EpiRoute
     if(!file_exists($file))
     {
       EpiException::raise(new EpiException("Config file ({$file}) does not exist"));
-      break; // need to simulate same behavior if exceptions are turned off
     }
 
     $parsed_array = parse_ini_file($file, true);


### PR DESCRIPTION
To use openphoto with PHP7, removed break in line 90 :

break; // need to simulate same behavior if exceptions are turned off